### PR TITLE
send 'markdown' format request to firecrawl to get complete markdown …

### DIFF
--- a/composables/useWebSearch.ts
+++ b/composables/useWebSearch.ts
@@ -28,7 +28,12 @@ export const useWebSearch = (): WebSearchFunction => {
         apiUrl: webSearchApiBase,
       })
       return async (q: string, o: WebSearchOptions) => {
-        const results = await fc.search(q, o)
+        const results = await fc.search(q, {
+          ...o,
+          scrapeOptions: {
+            formats: ['markdown']
+          }
+        })
         if (results.error) {
           throw new Error(results.error)
         }


### PR DESCRIPTION
…for search result pages. Include scrapeOptions with formats: ['markdown'] to get complete markdown content for each search result otherwise it defaults to getting SERP results (url, title, description).