### PR TITLE
Added Google PSE as an alternative web search provider

### DIFF
--- a/app/components/ConfigManager.vue
+++ b/app/components/ConfigManager.vue
@@ -321,6 +321,26 @@
                   :placeholder="$t('settings.webSearch.apiKey')"
                 />
               </UFormField>
+
+              <template v-if="config.webSearch.provider === 'google-pse'">
+                <UFormField
+                  :label="
+                    $t('settings.webSearch.providers.google-pse.pseIdLabel')
+                  "
+                  required
+                >
+                  <UInput
+                    v-model="config.webSearch.googlePseId"
+                    class="w-full"
+                    :placeholder="
+                      $t(
+                        'settings.webSearch.providers.google-pse.pseIdPlaceholder',
+                      )
+                    "
+                  />
+                </UFormField>
+              </template>
+
               <UFormField
                 v-if="selectedWebSearchProvider?.supportsCustomApiBase"
                 :label="$t('settings.webSearch.apiBase')"
@@ -384,14 +404,6 @@
                     :items="tavilySearchTopicOptions"
                     placeholder="general"
                   />
-                </UFormField>
-              </template>
-              <template v-if="config.webSearch.provider === 'google-pse'">
-                <UFormField :label="$t('settings.webSearch.providers.google-pse.pseIdLabel')" required>
-                  <UInput
-                    v-model="config.webSearch.googlePseId"
-                    class="w-full"
-                    :placeholder="$t('settings.webSearch.providers.google-pse.pseIdPlaceholder')" />
                 </UFormField>
               </template>
             </div>

--- a/app/components/ConfigManager.vue
+++ b/app/components/ConfigManager.vue
@@ -91,6 +91,13 @@
       link: 'https://www.firecrawl.dev/app/api-keys',
       supportsCustomApiBase: true,
     },
+    {
+      label: 'Google PSE', // Or use i18n: t('settings.webSearch.providers.google-pse.title')
+      value: 'google-pse',
+      help: 'settings.webSearch.providers.google-pse.help', // Add corresponding i18n key
+      link: 'https://programmablesearchengine.google.com/', // Link to Google PSE console
+      supportsCustomApiBase: false, // Google PSE usually doesn't support custom base URLs in the same way
+    },
   ])
   const tavilySearchTopicOptions = ['general', 'news', 'finance']
   const selectedAiProvider = computed(() =>
@@ -378,6 +385,14 @@
                     :items="tavilySearchTopicOptions"
                     placeholder="general"
                   />
+                </UFormField>
+              </template>
+              <template v-if="config.webSearch.provider === 'google-pse'">
+                <UFormField :label="$t('settings.webSearch.providers.google-pse.pseIdLabel')" required>
+                  <UInput
+                    v-model="config.webSearch.googlePseId"
+                    class="w-full"
+                    :placeholder="$t('settings.webSearch.providers.google-pse.pseIdPlaceholder')" />
                 </UFormField>
               </template>
             </div>

--- a/app/components/ConfigManager.vue
+++ b/app/components/ConfigManager.vue
@@ -92,11 +92,10 @@
       supportsCustomApiBase: true,
     },
     {
-      label: 'Google PSE', // Or use i18n: t('settings.webSearch.providers.google-pse.title')
+      label: 'Google PSE',
       value: 'google-pse',
-      help: 'settings.webSearch.providers.google-pse.help', // Add corresponding i18n key
+      help: 'settings.webSearch.providers.google-pse.help',
       link: 'https://programmablesearchengine.google.com/', // Link to Google PSE console
-      supportsCustomApiBase: false, // Google PSE usually doesn't support custom base URLs in the same way
     },
   ])
   const tavilySearchTopicOptions = ['general', 'news', 'finance']

--- a/app/composables/useWebSearch.ts
+++ b/app/composables/useWebSearch.ts
@@ -46,6 +46,51 @@ export const useWebSearch = (): WebSearchFunction => {
           }))
       }
     }
+    case 'google-pse': {
+      const apiKey = config.webSearch.apiKey
+      const pseId = config.webSearch.googlePseId
+
+      return async (q: string, o: WebSearchOptions) => {
+        if (!apiKey || !pseId) {
+          throw new Error('Google PSE API key or ID not set')
+        }
+
+        // Construct Google PSE API URL
+        // Ref: https://developers.google.com/custom-search/v1/using_rest
+        const searchParams = new URLSearchParams({
+          key: apiKey,
+          cx: pseId,
+          q: q,
+          num: o.maxResults?.toString() || '5', // Default to 5 results if not specified
+          // Add other params like 'lr' based on lang if needed: o.lang ? `lang_${o.lang}` : undefined
+        });
+        if (o.lang) {
+          searchParams.append('lr', `lang_${o.lang}`); // Adjust language parameter format as needed by PSE API
+        }
+
+        const apiUrl = `https://www.googleapis.com/customsearch/v1?${searchParams.toString()}`;
+
+        try {
+          const response = await $fetch<{ items?: Array<{ title: string; link: string; snippet: string }> }>(apiUrl, { method: 'GET' });
+
+          if (!response.items) {
+            return [];
+          }
+
+          // Map response to WebSearchResult format
+          return response.items.map((item) => ({
+            content: item.snippet, // Use snippet as content
+            url: item.link,
+            title: item.title,
+          }));
+        } catch (error: any) {
+          console.error('Google PSE search failed:', error);
+          // Attempt to parse Google API error format
+          const errorMessage = error?.data?.error?.message || error.message || 'Unknown error';
+          throw new Error(`Google PSE Error: ${errorMessage}`);
+        }
+      }
+    }
     case 'tavily':
     default: {
       const tvly = tavily({

--- a/app/composables/useWebSearch.ts
+++ b/app/composables/useWebSearch.ts
@@ -61,11 +61,10 @@ export const useWebSearch = (): WebSearchFunction => {
           key: apiKey,
           cx: pseId,
           q: q,
-          num: o.maxResults?.toString() || '5', // Default to 5 results if not specified
-          // Add other params like 'lr' based on lang if needed: o.lang ? `lang_${o.lang}` : undefined
+          num: o.maxResults?.toString() || '5',
         });
         if (o.lang) {
-          searchParams.append('lr', `lang_${o.lang}`); // Adjust language parameter format as needed by PSE API
+          searchParams.append('lr', `lang_${o.lang}`);
         }
 
         const apiUrl = `https://www.googleapis.com/customsearch/v1?${searchParams.toString()}`;

--- a/app/stores/config.ts
+++ b/app/stores/config.ts
@@ -9,7 +9,7 @@ export type ConfigAiProvider =
   | 'deepseek'
   | 'ollama'
 
-export type ConfigWebSearchProvider = 'tavily' | 'firecrawl'
+export type ConfigWebSearchProvider = 'tavily' | 'firecrawl' | 'google-pse'
 
 export interface ConfigAi {
   provider: ConfigAiProvider
@@ -31,6 +31,7 @@ export interface ConfigWebSearch {
   tavilyAdvancedSearch?: boolean
   /** Tavily: search topic. Defaults to `general` */
   tavilySearchTopic?: 'general' | 'news' | 'finance'
+  googlePseId?: string; // Google PSE ID
 }
 
 export interface Config {
@@ -47,6 +48,7 @@ function validateConfig(config: Config) {
   if (ws.provider === 'tavily' && !ws.apiKey) return false
   // Either apiBase or apiKey is required for firecrawl
   if (ws.provider === 'firecrawl' && !ws.apiBase && !ws.apiKey) return false
+  if (ws.provider === 'google-pse' && (!ws.apiKey || !ws.googlePseId)) return false; // Require API Key and PSE ID
   if (typeof ws.concurrencyLimit !== 'undefined' && ws.concurrencyLimit! < 1)
     return false
   return true

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -49,6 +49,14 @@
         },
         "firecrawl": {
           "help": "Get one API key at {0} if you are using the official service."
+        },
+        "google-pse": {
+          "title": "Google PSE",
+          "help": "Uses Google Programmable Search Engine. Requires an API Key and a PSE ID from Google Cloud Console / PSE Console. Find details at {0}.",
+          "apiKeyLabel": "Google API Key",
+          "apiKeyPlaceholder": "Enter your Google API Key",
+          "pseIdLabel": "Programmable Search Engine ID (cx)",
+          "pseIdPlaceholder": "Enter your PSE ID (cx value)"
         }
       },
       "concurrencyLimitHelp": "Limit the concurrent search tasks. This is useful to avoid overloading the search provider and causing requests to fail.",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -49,6 +49,14 @@
         },
         "firecrawl": {
           "help": "Ontvang een API-sleutel bij {0} als u de officiële service gebruikt."
+        },
+        "google-pse": {
+          "title": "Google PSE",
+          "help": "Gebruikt Google Programmable Search Engine. Vereist een API-sleutel en een PSE-ID van Google Cloud Console / PSE Console. Vind details op {0}.",
+          "apiKeyLabel": "Google API-sleutel",
+          "apiKeyPlaceholder": "Voer uw Google API-sleutel in",
+          "pseIdLabel": "Programmable Search Engine ID (cx)",
+          "pseIdPlaceholder": "Voer uw PSE ID (cx-waarde) in"
         }
       },
       "concurrencyLimitHelp": "Beperk de gelijktijdige zoektaken. Dit is handig om te voorkomen dat de zoekmachine overbelast raakt en verzoeken mislukken.",

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -49,6 +49,14 @@
           "searchTopic": "搜索领域",
           "advancedSearch": "高质量搜索",
           "searchTopicHelp": "搜索特定领域的信息，获得更精确的结果。默认为“通用” (general)。"
+        },
+        "google-pse": {
+          "title": "Google PSE",
+          "help": "使用 Google 可编程搜索引擎。需要来自 Google Cloud Console / PSE Console 的 API 密钥和 PSE ID。在 {0} 查看详情。",
+          "apiKeyLabel": "Google API 密钥",
+          "apiKeyPlaceholder": "输入你的 Google API 密钥",
+          "pseIdLabel": "可编程搜索引擎 ID (cx)",
+          "pseIdPlaceholder": "输入你的 PSE ID (cx 值)"
         }
       },
       "concurrencyLimit": "并发数",


### PR DESCRIPTION
Added Google PSE (https://programmablesearchengine.google.com/) as an alternative web search provider to use instead of Tavily and Firecrawl