### PR TITLE
docs: remove Swiftproxy sponsor section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,6 @@ Currently available providers:
 
 Please give a 🌟 Star if you like this project!
 
-## Sponsor
-
-<a href="https://www.swiftproxy.net/?ref=anotiawang">
-<img width="415" alt="image" src="https://github.com/user-attachments/assets/df889a5f-c4fc-4209-b49d-9c7dc8b9c3ca" />
-</a>
-
-**Unlock Reliable Proxy Services with Swiftproxy**
-
-With Swiftproxy, you can access high-performance, secure proxies to enhance your web automation, privacy, and data collection efforts. Our services are trusted by developers and businesses to scale scraping tasks and ensure a safe online experience. Get started today at Swiftproxy.net. Use the coupon `GHB5` to get 10% off!
-
----
-
 <video width="500" src="https://github.com/user-attachments/assets/8f9baa43-a74e-4613-aebb-1bcc29a686f0" controls></video>
 
 ## Recent updates


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the Swiftproxy sponsor block from `README.md`, including the heading, banner image, and promotional copy.

## Changes

- Deleted the entire `## Sponsor` section from the English README
- `README_zh.md` was already free of sponsor content; no changes needed there

## Testing

- Documentation-only change; no code or build impact.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f88a3c1-2228-4710-8ab8-8cbf22ef22c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f88a3c1-2228-4710-8ab8-8cbf22ef22c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

