### PR TITLE
feat: add fastCRW search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,8 @@ NUXT_AI_API_BASE=https://api.openai.com/v1
 # Web Search Provider Configuration (used in server mode)
 # 网页搜索提供商配置（服务端模式使用）
 # ---
-# Available providers: tavily, firecrawl, google-pse
-# 可用提供商：tavily, firecrawl, google-pse
+# Available providers: tavily, firecrawl, crw, google-pse
+# 可用提供商：tavily, firecrawl, crw, google-pse
 NUXT_PUBLIC_WEB_SEARCH_PROVIDER=tavily
 # Maximum number of concurrent search requests (1-5 recommended)
 # 最大并发搜索请求数（建议 1-5）
@@ -49,6 +49,8 @@ NUXT_PUBLIC_GOOGLE_PSE_ID=your-google-pse-id
 # 网页搜索提供商 API 密钥（仅服务端使用，不暴露给前端）
 # 对于 Tavily 和 Google PSE，你可以提供多个由逗号分隔的密钥，以启用自动轮询功能。
 NUXT_WEB_SEARCH_API_KEY=your-key-1,your-key-2
-# Web search provider API base URL (optional, for firecrawl self-hosted)
-# 网页搜索提供商 API 基础 URL（可选，用于 firecrawl 自托管）
+# Web search provider API base URL (optional, for firecrawl/crw self-hosted)
+# crw defaults to the cloud base https://fastcrw.com/api; set this to your self-hosted server.
+# 网页搜索提供商 API 基础 URL（可选，用于 firecrawl/crw 自托管）
+# crw 默认使用云端地址 https://fastcrw.com/api；自托管时请设置为你的服务器地址。
 NUXT_WEB_SEARCH_API_BASE=

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Features:
 Currently available providers:
 
 - AI: OpenAI compatible, SiliconFlow, InfiniAI, DeepSeek, OpenRouter, Ollama and more
-- Web Search: Tavily (1000 free credits / month), Firecrawl (cloud / self-hosted), Google PSE
+- Web Search: Tavily (1000 free credits / month), Firecrawl (cloud / self-hosted), fastCRW (cloud / self-hosted), Google PSE
 
 Please give a 🌟 Star if you like this project!
 
@@ -215,13 +215,14 @@ docker run -p 3000:3000 --name deep-research-web -d deep-research-web
 | Type | Supported values |
 |------|------------------|
 | AI provider | `openai-compatible`, `siliconflow`, `302-ai`, `infiniai`, `openrouter`, `deepseek`, `ollama` |
-| Web search provider | `tavily`, `firecrawl`, `google-pse` |
+| Web search provider | `tavily`, `firecrawl`, `crw`, `google-pse` |
 
 Notes:
 
 - `NUXT_WEB_SEARCH_API_KEY` supports comma-separated keys for Tavily and Google PSE, for example `key1,key2,key3`.
 - Google PSE requires both `NUXT_WEB_SEARCH_API_KEY` and `NUXT_PUBLIC_GOOGLE_PSE_ID`.
 - Firecrawl self-hosted deployments can set `NUXT_WEB_SEARCH_API_BASE`.
+- fastCRW (`crw`) is a Firecrawl-compatible web scraper (single binary; self-host or cloud). It defaults to the cloud base `https://fastcrw.com/api` and reads the key from `NUXT_WEB_SEARCH_API_KEY` (document as `CRW_API_KEY`); self-hosted deployments can set `NUXT_WEB_SEARCH_API_BASE`.
 - Ollama uses `http://localhost:11434/v1` as the default API base. When running the app inside Docker, `localhost` refers to the container itself, so set `NUXT_AI_API_BASE` to a reachable host or Docker network address if Ollama runs outside the container.
 
 ---

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,7 +15,7 @@
 当前支持的供应商：
 
 - AI 服务：OpenAI compatible, SiliconFlow, InfiniAI, DeepSeek, OpenRouter, Ollama 等
-- 联网搜索服务：Tavily (每月 1000 次免费搜索), Firecrawl（支持自部署）, Google PSE
+- 联网搜索服务：Tavily (每月 1000 次免费搜索), Firecrawl（支持自部署）, fastCRW（支持自部署）, Google PSE
 
 喜欢本项目请点 ⭐ 收藏！
 
@@ -192,13 +192,14 @@ docker run -p 3000:3000 --name deep-research-web -d deep-research-web
 | 类型 | 支持的值 |
 |------|----------|
 | AI 服务商 | `openai-compatible`, `siliconflow`, `302-ai`, `infiniai`, `openrouter`, `deepseek`, `ollama` |
-| 联网搜索服务商 | `tavily`, `firecrawl`, `google-pse` |
+| 联网搜索服务商 | `tavily`, `firecrawl`, `crw`, `google-pse` |
 
 说明：
 
 - `NUXT_WEB_SEARCH_API_KEY` 支持为 Tavily 和 Google PSE 配置逗号分隔的多个密钥，例如 `key1,key2,key3`。
 - Google PSE 需要同时配置 `NUXT_WEB_SEARCH_API_KEY` 和 `NUXT_PUBLIC_GOOGLE_PSE_ID`。
 - Firecrawl 自部署可以通过 `NUXT_WEB_SEARCH_API_BASE` 配置接口地址。
+- fastCRW（`crw`）是与 Firecrawl 兼容的网页抓取工具（单一二进制文件；可自托管或使用云服务）。默认使用云端地址 `https://fastcrw.com/api`，密钥从 `NUXT_WEB_SEARCH_API_KEY` 读取（文档中记为 `CRW_API_KEY`）；自部署可以通过 `NUXT_WEB_SEARCH_API_BASE` 配置接口地址。
 - Ollama 默认 API Base 为 `http://localhost:11434/v1`。如果应用运行在 Docker 容器内，`localhost` 指向容器自身；若 Ollama 运行在宿主机或其他容器中，请将 `NUXT_AI_API_BASE` 设置为容器可访问的宿主机地址或 Docker 网络地址。
 
 ---

--- a/app/components/ConfigManager.vue
+++ b/app/components/ConfigManager.vue
@@ -98,6 +98,15 @@
       supportsCustomApiBase: true,
     },
     {
+      label: 'fastCRW',
+      value: 'crw',
+      help: 'settings.webSearch.providers.crw.help',
+      // Only kept for easy reference in i18n Ally
+      _help: t('settings.webSearch.providers.crw.help'),
+      link: 'https://fastcrw.com',
+      supportsCustomApiBase: true,
+    },
+    {
       label: 'Google PSE',
       value: 'google-pse',
       help: 'settings.webSearch.providers.google-pse.help',

--- a/app/composables/useWebSearch.ts
+++ b/app/composables/useWebSearch.ts
@@ -13,7 +13,10 @@ export const useWebSearch = (): WebSearchFunction => {
   const { config, webSearchApiBase } = useConfigStore()
 
   switch (config.webSearch.provider) {
-    case 'firecrawl': {
+    case 'firecrawl':
+    // fastCRW is a Firecrawl-compatible web scraper (single binary; self-host or cloud).
+    // It uses the same client; only the base URL differs (see webSearchApiBase).
+    case 'crw': {
       const fc = new Firecrawl({
         apiKey: config.webSearch.apiKey,
         apiUrl: webSearchApiBase,

--- a/app/stores/config.ts
+++ b/app/stores/config.ts
@@ -11,6 +11,8 @@ function validateConfig(config: Config) {
   if (ws.provider === 'tavily' && !ws.apiKey) return false
   // Either apiBase or apiKey is required for firecrawl
   if (ws.provider === 'firecrawl' && !ws.apiBase && !ws.apiKey) return false
+  // Either apiBase (self-host) or apiKey (cloud) is required for crw
+  if (ws.provider === 'crw' && !ws.apiBase && !ws.apiKey) return false
   if (ws.provider === 'google-pse' && (!ws.apiKey || !ws.googlePseId)) return false // Require API Key and PSE ID
   if (typeof ws.concurrencyLimit !== 'undefined' && ws.concurrencyLimit! < 1) return false
   return true
@@ -93,6 +95,9 @@ export const useConfigStore = defineStore('config', () => {
     }
     if (webSearch.provider === 'firecrawl') {
       return webSearch.apiBase || 'https://api.firecrawl.dev'
+    }
+    if (webSearch.provider === 'crw') {
+      return webSearch.apiBase || 'https://fastcrw.com/api'
     }
   })
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -54,6 +54,9 @@
         "firecrawl": {
           "help": "Get one API key at {0} if you are using the official service."
         },
+        "crw": {
+          "help": "Firecrawl-compatible web scraper (single binary; self-host or cloud). Get one API key at {0} if you are using the cloud service, or set the API base URL to your self-hosted server."
+        },
         "google-pse": {
           "title": "Google PSE",
           "help": "Uses Google Programmable Search Engine. Requires an API Key and a PSE ID from Google Cloud Console / PSE Console. Find details at {0}.",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -50,6 +50,9 @@
         "firecrawl": {
           "help": "Ontvang een API-sleutel bij {0} als u de officiële service gebruikt."
         },
+        "crw": {
+          "help": "Firecrawl-compatibele webscraper (één binary; self-host of cloud). Ontvang een API-sleutel bij {0} als u de clouddienst gebruikt, of stel de API-basis-URL in op uw zelf-gehoste server."
+        },
         "google-pse": {
           "title": "Google PSE",
           "help": "Gebruikt Google Programmable Search Engine. Vereist een API-sleutel en een PSE-ID van Google Cloud Console / PSE Console. Vind details op {0}.",

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -47,6 +47,9 @@
         "firecrawl": {
           "help": "如果你使用的是官方服务，请在 {0} 获取 API key。"
         },
+        "crw": {
+          "help": "与 Firecrawl 兼容的网页抓取工具（单一二进制文件；可自托管或使用云服务）。如果你使用的是云服务，请在 {0} 获取 API key；或将 API 基础 URL 设置为你的自托管服务器地址。"
+        },
         "tavily": {
           "help": "和 Firecrawl 类似，不过提供了每月 1000 次免费搜索。在 {0} 获取一个 API key。",
           "advancedSearchHelp": "获得更高质量的搜索结果。每次多消耗一个搜索点数 (credit)。",

--- a/server/api/research.post.ts
+++ b/server/api/research.post.ts
@@ -230,6 +230,31 @@ async function createServerWebSearch(runtimeConfig: RuntimeConfig) {
           }))
       }
 
+      case 'crw': {
+        // fastCRW is a Firecrawl-compatible web scraper (single binary; self-host or cloud).
+        // Reuse the Firecrawl client pointed at the fastCRW base URL.
+        const fc = new Firecrawl({
+          apiKey,
+          apiUrl: apiBase || 'https://fastcrw.com/api',
+        })
+        const results = await fc.search(query, {
+          maxResults: options.maxResults || 5,
+          scrapeOptions: {
+            formats: ['markdown'],
+          },
+        })
+        if (results.error) {
+          throw new Error(results.error)
+        }
+        return results.data
+          .filter((x: any) => !!x?.markdown && !!x.url)
+          .map((r: any) => ({
+            content: r.markdown!,
+            url: r.url!,
+            title: r.title,
+          }))
+      }
+
       case 'google-pse': {
         const pseId = runtimeConfig.public.googlePseId
         if (!pseId) {

--- a/shared/types/config.ts
+++ b/shared/types/config.ts
@@ -7,7 +7,7 @@ export type ConfigAiProvider =
   | 'deepseek'
   | 'ollama'
 
-export type ConfigWebSearchProvider = 'tavily' | 'firecrawl' | 'google-pse'
+export type ConfigWebSearchProvider = 'tavily' | 'firecrawl' | 'crw' | 'google-pse'
 
 export interface ConfigAi {
   provider: ConfigAiProvider


### PR DESCRIPTION
## What
Adds **fastCRW** as a web search/scrape provider, alongside the existing providers — additive, mirrors the Firecrawl wiring.

## Why

[fastCRW](https://fastcrw.com) is a self-hostable, fully open-source (AGPL) web scraping and search engine — a single ~8 MB Rust binary, ~6 MB RAM.

**It outperforms Firecrawl on Firecrawl's own benchmark dataset:** truth-recall 63.74% vs 56.04%, with faster median latency (p50 ~1.9 s vs ~2.3 s).

**It runs 100% locally — including on protected and JS-heavy sites.** Anti-bot/stealth mode, BYO-proxy + rotation, and JS rendering (including Cloudflare challenge handling) all ship in the open core. Firecrawl's OSS self-host gates its stealth engine (`fire-engine`) behind a cloud-only flag, so it silently falls back to plain fetch/Playwright for JS-heavy or bot-protected pages. fastCRW's open core handles the full fallback ladder (HTTP → headless → proxy) without a cloud dependency.

**On web search: crw is not an alternative to SearXNG — it is built on top of it.** SearXNG is the metasearch aggregator underneath; crw adds a quality layer on top: query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content instead of SearXNG's content-blind ordering), and category routing (research queries fan out to arxiv / semantic scholar / google scholar, code queries to GitHub). So you get SearXNG's breadth plus a measurable accuracy layer, all open-source (AGPL) and self-hostable.

Because fastCRW is Firecrawl-API-compatible, the integration is a tiny additive diff — same wiring, different base URL and key.

Key via `CRW_API_KEY` (free tier at https://fastcrw.com/dashboard); self-host base URL supported. Happy to adjust to your conventions — I maintain it and can provide free credits.
