### PR TITLE
feat: add optional you.com search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,8 @@ NUXT_AI_API_BASE=https://api.openai.com/v1
 # Web Search Provider Configuration (used in server mode)
 # 网页搜索提供商配置（服务端模式使用）
 # ---
-# Available providers: tavily, firecrawl, crw, google-pse
-# 可用提供商：tavily, firecrawl, crw, google-pse
+# Available providers: tavily, firecrawl, crw, google-pse, youcom
+# 可用提供商：tavily, firecrawl, crw, google-pse, youcom
 NUXT_PUBLIC_WEB_SEARCH_PROVIDER=tavily
 # Maximum number of concurrent search requests (1-5 recommended)
 # 最大并发搜索请求数（建议 1-5）
@@ -46,8 +46,10 @@ NUXT_PUBLIC_TAVILY_SEARCH_TOPIC=general
 NUXT_PUBLIC_GOOGLE_PSE_ID=your-google-pse-id
 # Web search provider API key (server-side only, not exposed to frontend)
 # For Tavily and Google PSE, you can provide multiple keys separated by commas for automatic polling.
+# For youcom, the key is optional: without a key the keyless endpoint (limited daily quota) is used.
 # 网页搜索提供商 API 密钥（仅服务端使用，不暴露给前端）
 # 对于 Tavily 和 Google PSE，你可以提供多个由逗号分隔的密钥，以启用自动轮询功能。
+# 对于 youcom，密钥为可选：未设置时使用免密钥端点（每日配额有限）。
 NUXT_WEB_SEARCH_API_KEY=your-key-1,your-key-2
 # Web search provider API base URL (optional, for firecrawl/crw self-hosted)
 # crw defaults to the cloud base https://fastcrw.com/api; set this to your self-hosted server.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ docker run -p 3000:3000 --name deep-research-web -d deep-research-web
 | Type | Supported values |
 |------|------------------|
 | AI provider | `openai-compatible`, `siliconflow`, `302-ai`, `infiniai`, `openrouter`, `requesty`, `deepseek`, `ollama`, `litellm` |
-| Web search provider | `tavily`, `firecrawl`, `crw`, `google-pse` |
+| Web search provider | `tavily`, `firecrawl`, `crw`, `google-pse`, `youcom` |
 
 Notes:
 
@@ -147,6 +147,7 @@ Notes:
 - Google PSE requires both `NUXT_WEB_SEARCH_API_KEY` and `NUXT_PUBLIC_GOOGLE_PSE_ID`.
 - Firecrawl self-hosted deployments can set `NUXT_WEB_SEARCH_API_BASE`.
 - fastCRW (`crw`) is a Firecrawl-compatible web scraper (single binary; self-host or cloud). It defaults to the cloud base `https://fastcrw.com/api` and reads the key from `NUXT_WEB_SEARCH_API_KEY` (document as `CRW_API_KEY`); self-hosted deployments can set `NUXT_WEB_SEARCH_API_BASE`.
+- You.com (`youcom`) reads its key from `NUXT_WEB_SEARCH_API_KEY` (optional, comma-separated keys supported for rotation). Without a key it uses the keyless endpoint with a limited daily quota; get a key at https://you.com/platform/api-keys.
 - Ollama uses `http://localhost:11434/v1` as the default API base. When running the app inside Docker, `localhost` refers to the container itself, so set `NUXT_AI_API_BASE` to a reachable host or Docker network address if Ollama runs outside the container.
 - LiteLLM uses `http://localhost:4000/v1` as the default API base. Its API key is optional when the proxy does not require authentication; set `NUXT_AI_API_BASE` when the proxy is not reachable at the default local address.
 - Requesty uses `https://router.requesty.ai/v1` as the default API base and expects model IDs in `provider/model` format, such as `openai/gpt-4o`.

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,7 +18,7 @@ Deep Research Web 能把一个研究问题变成一份带引用的报告：自�
 当前支持的供应商：
 
 - AI 服务：OpenAI compatible, SiliconFlow, InfiniAI, DeepSeek, OpenRouter, Requesty, Ollama, LiteLLM 等
-- 联网搜索服务：Tavily (每月 1000 次免费搜索), Firecrawl（支持自部署）, fastCRW（支持自部署）, Google PSE
+- 联网搜索服务：Tavily (每月 1000 次免费搜索), Firecrawl（支持自部署）, fastCRW（支持自部署）, Google PSE, You.com（免密钥可用）
 
 喜欢本项目请点 ⭐ 收藏！
 
@@ -119,7 +119,7 @@ docker run -p 3000:3000 --name deep-research-web -d deep-research-web
 | 类型 | 支持的值 |
 |------|----------|
 | AI 服务商 | `openai-compatible`, `siliconflow`, `302-ai`, `infiniai`, `openrouter`, `requesty`, `deepseek`, `ollama`, `litellm` |
-| 联网搜索服务商 | `tavily`, `firecrawl`, `crw`, `google-pse` |
+| 联网搜索服务商 | `tavily`, `firecrawl`, `crw`, `google-pse`, `youcom` |
 
 说明：
 
@@ -127,6 +127,7 @@ docker run -p 3000:3000 --name deep-research-web -d deep-research-web
 - Google PSE 需要同时配置 `NUXT_WEB_SEARCH_API_KEY` 和 `NUXT_PUBLIC_GOOGLE_PSE_ID`。
 - Firecrawl 自部署可以通过 `NUXT_WEB_SEARCH_API_BASE` 配置接口地址。
 - fastCRW（`crw`）是与 Firecrawl 兼容的网页抓取工具（单一二进制文件；可自托管或使用云服务）。默认使用云端地址 `https://fastcrw.com/api`，密钥从 `NUXT_WEB_SEARCH_API_KEY` 读取（文档中记为 `CRW_API_KEY`）；自部署可以通过 `NUXT_WEB_SEARCH_API_BASE` 配置接口地址。
+- You.com（`youcom`）从 `NUXT_WEB_SEARCH_API_KEY` 读取密钥（可选，支持逗号分隔多密钥轮询）。未设置密钥时使用免密钥端点（每日配额有限）；可在 https://you.com/platform/api-keys 获取密钥。
 - Ollama 默认 API Base 为 `http://localhost:11434/v1`。如果应用运行在 Docker 容器内，`localhost` 指向容器自身；若 Ollama 运行在宿主机或其他容器中，请将 `NUXT_AI_API_BASE` 设置为容器可访问的宿主机地址或 Docker 网络地址。
 - LiteLLM 默认 API Base 为 `http://localhost:4000/v1`。当代理未启用认证时，API 密钥可以留空；如果代理无法通过默认本地地址访问，请设置 `NUXT_AI_API_BASE`。
 - Requesty 默认 API Base 为 `https://router.requesty.ai/v1`，模型 ID 使用 `provider/model` 格式，例如 `openai/gpt-4o`。

--- a/app/components/ConfigManager.vue
+++ b/app/components/ConfigManager.vue
@@ -127,7 +127,17 @@
       label: 'Google PSE',
       value: 'google-pse',
       help: 'settings.webSearch.providers.google-pse.help',
+      // Only kept for easy reference in i18n Ally
+      _help: t('settings.webSearch.providers.google-pse.help'),
       link: 'https://programmablesearchengine.google.com/', // Link to Google PSE console
+    },
+    {
+      label: 'You.com',
+      value: 'youcom',
+      help: 'settings.webSearch.providers.youcom.help',
+      // Only kept for easy reference in i18n Ally
+      _help: t('settings.webSearch.providers.youcom.help'),
+      link: 'https://you.com/platform/api-keys',
     },
   ])
   const tavilySearchTopicOptions = ['general', 'news', 'finance']
@@ -349,12 +359,16 @@
               </UFormField>
               <UFormField
                 :label="$t('settings.webSearch.apiKey')"
-                :required="!config.webSearch.apiBase"
+                :required="!config.webSearch.apiBase && config.webSearch.provider !== 'youcom'"
               >
                 <PasswordInput
                   v-model="config.webSearch.apiKey"
                   class="w-full"
-                  :placeholder="$t('settings.webSearch.apiKey')"
+                  :placeholder="
+                    config.webSearch.provider === 'youcom'
+                      ? $t('settings.webSearch.providers.youcom.apiKeyPlaceholder')
+                      : $t('settings.webSearch.apiKey')
+                  "
                   :disabled="isServerMode"
                 />
               </UFormField>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -64,6 +64,10 @@
           "apiKeyPlaceholder": "Enter your Google API Key",
           "pseIdLabel": "Programmable Search Engine ID (cx)",
           "pseIdPlaceholder": "Enter your PSE ID (cx value)"
+        },
+        "youcom": {
+          "help": "Web search via the You.com Search API. Works without an API key (limited daily quota); add a key at {0} for higher limits.",
+          "apiKeyPlaceholder": "Optional — leave empty for the keyless free tier"
         }
       },
       "concurrencyLimitHelp": "Limit the concurrent search tasks. This is useful to avoid overloading the search provider and causing requests to fail.",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -64,6 +64,10 @@
           "apiKeyPlaceholder": "Google API 키를 입력하세요",
           "pseIdLabel": "프로그래밍 가능 검색 엔진 ID (cx)",
           "pseIdPlaceholder": "PSE ID(cx 값)를 입력하세요"
+        },
+        "youcom": {
+          "help": "You.com 검색 API를 통한 웹 검색. API 키 없이 사용할 수 있습니다(일일 할당량 제한); 더 높은 한도를 원하면 {0}에서 키를 발급받으세요.",
+          "apiKeyPlaceholder": "선택 사항 — 비워 두면 키 없는 무료 사용량이 적용됩니다"
         }
       },
       "concurrencyLimitHelp": "동시 검색 작업 수를 제한합니다. 검색 제공자에 과부하가 걸려 요청이 실패하는 것을 방지하는 데 유용합니다.",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -60,6 +60,10 @@
           "apiKeyPlaceholder": "Voer uw Google API-sleutel in",
           "pseIdLabel": "Programmable Search Engine ID (cx)",
           "pseIdPlaceholder": "Voer uw PSE ID (cx-waarde) in"
+        },
+        "youcom": {
+          "help": "Zoeken op het web via de You.com Search API. Werkt zonder API-sleutel (beperkt dagelijks quotum); voeg een sleutel toe op {0} voor hogere limieten.",
+          "apiKeyPlaceholder": "Optioneel — laat leeg voor de gratis sleutelloze variant"
         }
       },
       "concurrencyLimitHelp": "Beperk de gelijktijdige zoektaken. Dit is handig om te voorkomen dat de zoekmachine overbelast raakt en verzoeken mislukken.",

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -64,6 +64,10 @@
           "apiKeyPlaceholder": "输入你的 Google API 密钥",
           "pseIdLabel": "可编程搜索引擎 ID (cx)",
           "pseIdPlaceholder": "输入你的 PSE ID (cx 值)"
+        },
+        "youcom": {
+          "help": "通过 You.com 搜索 API 进行网页搜索。无需 API 密钥即可使用（每日配额有限）；在 {0} 获取密钥可获得更高限额。",
+          "apiKeyPlaceholder": "可选 — 留空则使用免密钥免费额度"
         }
       },
       "concurrencyLimit": "并发数",

--- a/lib/core/web-search.ts
+++ b/lib/core/web-search.ts
@@ -42,6 +42,20 @@ export type WebSearchConfig = {
 
 const FIRECRAWL_DEFAULT_API_BASE = 'https://api.firecrawl.dev'
 const CRW_DEFAULT_API_BASE = 'https://fastcrw.com/api'
+const YOUCOM_KEYLESS_SEARCH_URL = 'https://api.you.com/v1/agents/search'
+const YOUCOM_KEYED_SEARCH_URL = 'https://ydc-index.io/v1/search'
+
+/** Single item from the You.com search API `results.web` / `results.news` arrays. */
+interface YoucomSearchResult {
+  url?: string
+  title?: string
+  /** Curated summary of the page. */
+  description?: string
+  /** Excerpts from the page itself. */
+  snippets?: string[]
+  /** Publication date, e.g. `2025-07-14T00:00:00`. */
+  page_age?: string
+}
 
 export function resolveWebSearchApiBase(
   provider: ConfigWebSearchProvider,
@@ -53,7 +67,7 @@ export function resolveWebSearchApiBase(
   if (provider === 'crw') {
     return apiBase || CRW_DEFAULT_API_BASE
   }
-  // tavily / google-pse do not use a configurable API base in this project
+  // tavily / google-pse / youcom do not use a configurable API base in this project
   return undefined
 }
 
@@ -103,6 +117,20 @@ export function buildSearchFilters(provider: ConfigWebSearchProvider, options: W
   } else if (domains) limits.push('domains')
   if (options.intent === 'news') limits.push('news')
   if (provider === 'google-pse') return { google, firecrawl: {}, tavily: {}, limitations: limits }
+  if (provider === 'youcom')
+    return {
+      // The You.com search endpoints have no native time/domain/language
+      // params; the response always includes a `news` section for
+      // news-intent queries, so only the other constraints are reported.
+      google: {},
+      firecrawl: {},
+      tavily: {},
+      limitations: [
+        ...(time || hasDates ? ['time' as const] : []),
+        ...(domains ? ['domains' as const] : []),
+        ...(options.lang ? ['language' as const] : []),
+      ],
+    }
   if (provider === 'crw')
     return {
       google: {},
@@ -254,6 +282,80 @@ async function searchWithTavily(
     }))
 }
 
+/**
+ * You.com Web Search API.
+ *
+ * Two endpoints, selected by the presence of an API key:
+ * - Keyed: `https://ydc-index.io/v1/search` with `X-API-Key` (higher limits)
+ * - Keyless: `https://api.you.com/v1/agents/search` (limited daily quota per
+ *   IP; returns 402 once exhausted, which we surface as an error)
+ *
+ * Response shape (`results.web` and, for news-intent queries, `results.news`):
+ * items carry `url`, `title`, `description`, `snippets` (excerpts) and
+ * `page_age`. `description` is a curated summary while `snippets` are page
+ * excerpts, so both are joined into the result content.
+ */
+async function searchWithYoucom(
+  config: WebSearchConfig,
+  query: string,
+  options: WebSearchOptions,
+): Promise<WebSearchResult[]> {
+  const usingKey = !!config.apiKey
+  const apiUrl = new URL(usingKey ? YOUCOM_KEYED_SEARCH_URL : YOUCOM_KEYLESS_SEARCH_URL)
+  apiUrl.searchParams.set('query', query)
+  apiUrl.searchParams.set('count', (options.maxResults ?? 5).toString())
+
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    // Pin identity encoding: the keyless endpoint can advertise gzip with
+    // body bytes that Node's decoder rejects.
+    'Accept-Encoding': 'identity',
+  }
+  if (usingKey) headers['X-API-Key'] = config.apiKey!
+
+  try {
+    const response = await abortable(fetch(apiUrl, { headers }), options.signal)
+    if (!response.ok) {
+      let message = `HTTP ${response.status}`
+      try {
+        const body = (await response.json()) as { error?: { message?: string } }
+        if (body.error?.message) message = `${message}: ${body.error.message}`
+      } catch {
+        // Body is not JSON; keep the status-only message.
+      }
+      throw new Error(`You.com search failed (${usingKey ? 'keyed' : 'keyless'}): ${message}`)
+    }
+
+    const data = (await response.json()) as {
+      results?: {
+        web?: YoucomSearchResult[]
+        news?: YoucomSearchResult[]
+      }
+    }
+    const webResults = data.results?.web ?? []
+    const newsResults = data.results?.news ?? []
+
+    return [...webResults, ...newsResults]
+      .map((r) => {
+        const content = [r.description, ...(r.snippets ?? [])].filter(Boolean).join('\n').trim()
+        if (!r.url || !content) return undefined
+        return {
+          content,
+          sourceType: 'search-result' as const,
+          url: r.url,
+          title: r.title,
+          publishedAt: r.page_age,
+        }
+      })
+      .filter((r): r is WebSearchResult => !!r)
+  } catch (error: unknown) {
+    if (options.signal?.aborted || isAbortError(error)) throw error
+    console.error('You.com search failed:', error)
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    throw new Error(`You.com Error: ${message}`)
+  }
+}
+
 /** Run a single web search with the given provider config. */
 export async function searchWeb(
   config: WebSearchConfig,
@@ -269,6 +371,8 @@ export async function searchWeb(
       return searchWithFirecrawlCompatible(config, query, options)
     case 'google-pse':
       return searchWithGooglePse(config, query, options)
+    case 'youcom':
+      return searchWithYoucom(config, query, options)
     case 'tavily':
     default:
       return searchWithTavily(config, query, options)

--- a/lib/core/web-search.ts
+++ b/lib/core/web-search.ts
@@ -119,13 +119,13 @@ export function buildSearchFilters(provider: ConfigWebSearchProvider, options: W
   if (provider === 'google-pse') return { google, firecrawl: {}, tavily: {}, limitations: limits }
   if (provider === 'youcom')
     return {
-      // The You.com search endpoints have no native time/domain/language
-      // params; the response always includes a `news` section for
-      // news-intent queries, so only the other constraints are reported.
+      // This adapter does not apply native filters. A mixed web/news
+      // response does not enforce the caller's news intent.
       google: {},
       firecrawl: {},
       tavily: {},
       limitations: [
+        ...(options.intent === 'news' ? ['news' as const] : []),
         ...(time || hasDates ? ['time' as const] : []),
         ...(domains ? ['domains' as const] : []),
         ...(options.lang ? ['language' as const] : []),

--- a/server/api/research.post.ts
+++ b/server/api/research.post.ts
@@ -129,6 +129,7 @@ class ApiKeyPool {
 
 let apiKeyPool: ApiKeyPool | undefined
 let googleApiKeyPool: ApiKeyPool | undefined
+let youcomApiKeyPool: ApiKeyPool | undefined
 
 export default defineEventHandler(async (event) => {
   const runtimeConfig = useRuntimeConfig()
@@ -308,6 +309,34 @@ function createServerWebSearch(runtimeConfig: RuntimeConfig): WebSearchFunction 
       const selectedKeyConfig = pool.getNextKey()
       if (!selectedKeyConfig) {
         throw new Error('No active Google PSE API keys available.')
+      }
+      const currentApiKey = selectedKeyConfig.key
+      try {
+        const results = await searchWeb({ ...sharedConfig, apiKey: currentApiKey }, query, options)
+        pool.markKeySuccess(currentApiKey)
+        return results
+      } catch (e) {
+        if (options.signal?.aborted || isAbortError(e)) throw e
+        pool.markKeyError(currentApiKey)
+        throw e
+      }
+    }
+
+    if (provider === 'youcom') {
+      // You.com works keyless; when keys are configured, rotate them like
+      // the other keyed providers (comma-separated NUXT_WEB_SEARCH_API_KEY).
+      const pool = getOrCreateApiKeyPool(
+        youcomApiKeyPool,
+        (next) => {
+          youcomApiKeyPool = next
+        },
+        'youcom',
+        runtimeConfig,
+      )
+      const selectedKeyConfig = pool.getNextKey()
+      // No keys configured (and pool empty): keyless endpoint, no rotation.
+      if (!selectedKeyConfig) {
+        return searchWeb({ ...sharedConfig, apiKey: undefined }, query, options)
       }
       const currentApiKey = selectedKeyConfig.key
       try {

--- a/server/api/research.post.ts
+++ b/server/api/research.post.ts
@@ -268,7 +268,7 @@ function getOrCreateApiKeyPool(
   return next
 }
 
-function createServerWebSearch(runtimeConfig: RuntimeConfig): WebSearchFunction {
+export function createServerWebSearch(runtimeConfig: RuntimeConfig): WebSearchFunction {
   const search: WebSearchFunction = async (query: string, options: WebSearchOptions) => {
     const provider = runtimeConfig.public.webSearchProvider as ConfigWebSearchProvider
     const sharedConfig = {
@@ -323,6 +323,9 @@ function createServerWebSearch(runtimeConfig: RuntimeConfig): WebSearchFunction 
     }
 
     if (provider === 'youcom') {
+      if (!runtimeConfig.webSearchApiKey?.trim()) {
+        return searchWeb({ ...sharedConfig, apiKey: undefined }, query, options)
+      }
       // You.com works keyless; when keys are configured, rotate them like
       // the other keyed providers (comma-separated NUXT_WEB_SEARCH_API_KEY).
       const pool = getOrCreateApiKeyPool(
@@ -334,9 +337,8 @@ function createServerWebSearch(runtimeConfig: RuntimeConfig): WebSearchFunction 
         runtimeConfig,
       )
       const selectedKeyConfig = pool.getNextKey()
-      // No keys configured (and pool empty): keyless endpoint, no rotation.
       if (!selectedKeyConfig) {
-        return searchWeb({ ...sharedConfig, apiKey: undefined }, query, options)
+        throw new Error('No active You.com API keys available.')
       }
       const currentApiKey = selectedKeyConfig.key
       try {

--- a/shared/types/config.ts
+++ b/shared/types/config.ts
@@ -9,7 +9,7 @@ export type ConfigAiProvider =
   | 'ollama'
   | 'litellm'
 
-export type ConfigWebSearchProvider = 'tavily' | 'firecrawl' | 'crw' | 'google-pse'
+export type ConfigWebSearchProvider = 'tavily' | 'firecrawl' | 'crw' | 'google-pse' | 'youcom'
 
 export interface ConfigAi {
   provider: ConfigAiProvider

--- a/test/server-web-search.test.ts
+++ b/test/server-web-search.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { it } from 'node:test'
+import type { RuntimeConfig } from 'nuxt/schema'
+
+// Nitro supplies this global when loading the route in production.
+const globals = globalThis as any
+const previousHandler = globals.defineEventHandler
+globals.defineEventHandler = (handler: unknown) => handler
+const { createServerWebSearch } = await import('../server/api/research.post.ts')
+if (previousHandler === undefined) delete globals.defineEventHandler
+else globals.defineEventHandler = previousHandler
+
+function config(apiKey?: string) {
+  return {
+    public: { webSearchProvider: 'youcom' },
+    webSearchApiKey: apiKey,
+  } as RuntimeConfig
+}
+
+it('uses keyless You.com search without creating a key pool when no key is configured', async () => {
+  const previous = globalThis.fetch
+  const requests: URL[] = []
+  globalThis.fetch = async (input, init) => {
+    requests.push(new URL(String(input)))
+    assert.equal(new Headers(init?.headers).has('X-API-Key'), false)
+    return Response.json({
+      results: { web: [{ url: 'https://example.com', description: 'Result' }] },
+    })
+  }
+  try {
+    for (const key of [undefined, '', '   ']) {
+      const results = await createServerWebSearch(config(key))('Nuxt', {})
+      assert.equal(results[0]?.content, 'Result')
+    }
+    assert.equal(requests.length, 3)
+    assert.ok(
+      requests.every(
+        (url) => url.origin === 'https://api.you.com' && url.pathname === '/v1/agents/search',
+      ),
+    )
+  } finally {
+    globalThis.fetch = previous
+  }
+})
+
+it('rotates configured You.com keys and does not silently switch to keyless when all are disabled', async () => {
+  const previous = globalThis.fetch
+  const previousCwd = process.cwd()
+  const cacheRoot = mkdtempSync(path.join(tmpdir(), 'youcom-keypool-test-'))
+  const keys: (string | null)[] = []
+  let fail = false
+  globalThis.fetch = async (input, init) => {
+    assert.equal(new URL(String(input)).hostname, 'ydc-index.io')
+    keys.push(new Headers(init?.headers).get('X-API-Key'))
+    return fail ? new Response('', { status: 401 }) : Response.json({ results: { web: [] } })
+  }
+  process.chdir(cacheRoot)
+  try {
+    const search = createServerWebSearch(config('test-key-one, test-key-two'))
+    await search('Nuxt', {})
+    await search('Nuxt', {})
+    assert.deepEqual(keys, ['test-key-one', 'test-key-two'])
+    fail = true
+    for (let index = 0; index < 10; index++) {
+      await assert.rejects(() => search('Nuxt', {}), /HTTP 401/)
+    }
+    const requestCount = keys.length
+    await assert.rejects(() => search('Nuxt', {}), /No active You.com API keys available/)
+    assert.equal(keys.length, requestCount)
+  } finally {
+    globalThis.fetch = previous
+    process.chdir(previousCwd)
+    rmSync(cacheRoot, { recursive: true, force: true })
+  }
+})

--- a/test/web-search.test.ts
+++ b/test/web-search.test.ts
@@ -326,14 +326,14 @@ it('scrapes Firecrawl markdown through the installed SDK using the configured AP
 })
 
 describe('youcom provider', () => {
-  it('reports unsupported time/domain/language filters as limitations', () => {
+  it('reports unsupported news/time/domain/language filters as limitations', () => {
     const filters = buildSearchFilters('youcom', {
       intent: 'news',
       timeRange: 'week',
       includeDomains: ['example.com'],
       lang: 'en',
     })
-    assert.deepEqual(filters.limitations, ['time', 'domains', 'language'])
+    assert.deepEqual(filters.limitations, ['news', 'time', 'domains', 'language'])
     assert.deepEqual(buildSearchFilters('youcom', {}).limitations, [])
   })
 
@@ -438,4 +438,26 @@ describe('youcom provider', () => {
       globalThis.fetch = previous
     }
   })
+})
+
+it('reports the news limitation when You.com returns only web results', async () => {
+  const previous = globalThis.fetch
+  globalThis.fetch = async () =>
+    Response.json({
+      results: {
+        web: [{ url: 'https://example.com/docs', description: 'Product documentation' }],
+        news: [],
+      },
+    })
+  try {
+    const notices: string[][] = []
+    const results = await searchWeb({ provider: 'youcom' }, 'Nuxt', {
+      intent: 'news',
+      onNotice: (value) => notices.push(value),
+    })
+    assert.equal(results.length, 1)
+    assert.deepEqual(notices, [['news']])
+  } finally {
+    globalThis.fetch = previous
+  }
 })

--- a/test/web-search.test.ts
+++ b/test/web-search.test.ts
@@ -324,3 +324,118 @@ it('scrapes Firecrawl markdown through the installed SDK using the configured AP
     await new Promise<void>((resolve) => server.close(() => resolve()))
   }
 })
+
+describe('youcom provider', () => {
+  it('reports unsupported time/domain/language filters as limitations', () => {
+    const filters = buildSearchFilters('youcom', {
+      intent: 'news',
+      timeRange: 'week',
+      includeDomains: ['example.com'],
+      lang: 'en',
+    })
+    assert.deepEqual(filters.limitations, ['time', 'domains', 'language'])
+    assert.deepEqual(buildSearchFilters('youcom', {}).limitations, [])
+  })
+
+  it('sends the query through the keyless endpoint without auth headers', async () => {
+    const previous = globalThis.fetch
+    let requestedUrl: URL | undefined
+    let requestedHeaders: Record<string, string> = {}
+    globalThis.fetch = (async (input: any, init?: any) => {
+      requestedUrl = new URL(String(input))
+      requestedHeaders = init?.headers ?? {}
+      return Response.json({
+        results: {
+          web: [
+            {
+              url: 'https://example.com/one',
+              title: 'Result one',
+              description: 'A curated summary',
+              snippets: ['An excerpt from the page'],
+              page_age: '2026-09-01T00:00:00',
+            },
+          ],
+          news: [
+            {
+              url: 'https://example.com/news',
+              title: 'Result news',
+              description: 'A news summary',
+            },
+          ],
+        },
+      })
+    }) as typeof fetch
+    try {
+      const notices: string[][] = []
+      const results = await searchWeb({ provider: 'youcom' }, 'AI product launches', {
+        maxResults: 7,
+        onNotice: (value) => notices.push(value),
+      })
+      assert.equal(requestedUrl?.hostname, 'api.you.com')
+      assert.equal(requestedUrl?.pathname, '/v1/agents/search')
+      assert.equal(requestedUrl?.searchParams.get('query'), 'AI product launches')
+      assert.equal(requestedUrl?.searchParams.get('count'), '7')
+      assert.equal(requestedHeaders['X-API-Key'], undefined)
+      assert.equal(results.length, 2)
+      assert.equal(results[0]?.content, 'A curated summary\nAn excerpt from the page')
+      assert.equal(results[0]?.publishedAt, '2026-09-01T00:00:00')
+      assert.equal(results[0]?.sourceType, 'search-result')
+      assert.equal(results[1]?.content, 'A news summary')
+      // onNotice fires even with no limitations (same as other providers).
+      assert.deepEqual(notices, [[]])
+    } finally {
+      globalThis.fetch = previous
+    }
+  })
+
+  it('uses the keyed endpoint with X-API-Key when a key is configured', async () => {
+    const previous = globalThis.fetch
+    let requestedUrl: URL | undefined
+    let requestedHeaders: Record<string, string> = {}
+    globalThis.fetch = (async (input: any, init?: any) => {
+      requestedUrl = new URL(String(input))
+      requestedHeaders = init?.headers ?? {}
+      return Response.json({ results: { web: [] } })
+    }) as typeof fetch
+    try {
+      await searchWeb({ provider: 'youcom', apiKey: 'test-only' }, 'query')
+      assert.equal(requestedUrl?.hostname, 'ydc-index.io')
+      assert.equal(requestedUrl?.pathname, '/v1/search')
+      assert.equal(requestedHeaders['X-API-Key'], 'test-only')
+    } finally {
+      globalThis.fetch = previous
+    }
+  })
+
+  it('drops items without url or content and surfaces HTTP errors', async () => {
+    const previous = globalThis.fetch
+    globalThis.fetch = (async () =>
+      Response.json(
+        {
+          results: {
+            web: [
+              { title: 'No url', description: 'orphan' },
+              { url: 'https://example.com/empty', title: 'No text' },
+            ],
+          },
+        },
+        { status: 200 },
+      )) as typeof fetch
+    try {
+      assert.deepEqual(await searchWeb({ provider: 'youcom' }, 'query'), [])
+    } finally {
+      globalThis.fetch = previous
+    }
+
+    globalThis.fetch = (async () =>
+      new Response('Payment Required', { status: 402 })) as typeof fetch
+    try {
+      await assert.rejects(
+        () => searchWeb({ provider: 'youcom' }, 'query'),
+        /You.com search failed \(keyless\): HTTP 402/,
+      )
+    } finally {
+      globalThis.fetch = previous
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Adds You.com as an optional web search provider, following the same shape as the existing tavily / firecrawl / crw / google-pse providers.

The main difference from the existing providers: You.com exposes a keyless endpoint, so it works with **zero setup** — selecting `youcom` in settings (or `NUXT_PUBLIC_WEB_SEARCH_PROVIDER=youcom`) is enough to get started. Setting `NUXT_WEB_SEARCH_API_KEY` (single key or comma-separated for rotation, same as the other providers) switches to the keyed endpoint with higher limits.

## What changed

- `shared/types/config.ts` — `youcom` added to the provider union.
- `lib/core/web-search.ts` — `searchWithYoucom()`:
  - Endpoint selection by key presence: `https://ydc-index.io/v1/search` with `X-API-Key` when keyed, `https://api.you.com/v1/agents/search` when keyless.
  - Maps `results.web` + `results.news` items (`url` / `title` / `description` / `snippets` / `page_age`) to the project's `WebSearchResult`; `description` + `snippets` are joined into the content, `page_age` maps to `publishedAt`.
  - The endpoints have no native time / domain / language params, so those constraints are reported as provider limitations (same approach as `crw`), which means the model is told instead of silently ignoring them.
- `server/api/research.post.ts` — key rotation via the existing `ApiKeyPool` when keys are configured; falls back to the keyless call when the pool is empty.
- `app/components/ConfigManager.vue` — dropdown entry (with the same `_help` i18n-Ally pattern as the other providers); the API key field is no longer marked *required* when `youcom` is selected, and shows a "optional — leave empty for the keyless free tier" placeholder.
- `i18n/{en,zh,nl,ko}.json` — provider help + placeholder strings.
- `.env.example`, `README.md`, `README_zh.md` — provider list and a note about the optional key.
- `test/web-search.test.ts` — 4 new tests: filter-limitation reporting, keyless request shape (URL/query/count, no auth header, result mapping incl. news section), keyed request shape (`X-API-Key`), and malformed-item / HTTP-error handling.

No existing provider paths were touched beyond the shared union type, and default behavior is unchanged (tavily stays the default).

## Setup

```
NUXT_PUBLIC_WEB_SEARCH_PROVIDER=youcom
# optional, single key or comma-separated for rotation:
NUXT_WEB_SEARCH_API_KEY=your-key
```

Key: https://you.com/platform/api-keys (keyless usage has a limited daily quota and returns 402 once exhausted, which is surfaced as a regular provider error).

## Validation

- `pnpm test` — 169/169 pass (includes the 4 new tests).
- `pnpm lint` (prettier) — clean.
- Live check against the real keyless endpoint through the actual `searchWeb({ provider: 'youcom' })` code path returned real results.

## Notes

- You.com also ships prebuilt agent artifacts (MCP server at `https://api.you.com/mcp`, installable skills/plugins for Claude Code / Copilot CLI / Codex etc. via `npx skills add youdotcom-oss/agent-skills`), so this provider can complement those surfaces — but this PR is self-contained and doesn't depend on any of them.

Happy to adjust the shape if you'd rather have the keyless mode behind a separate provider value, or anything else moved around.
